### PR TITLE
chore: github auto assign 추가

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,23 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - khcdev
+  - zoeyul
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 1
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+numberOfAssignees: 1
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip


### PR DESCRIPTION
## PR 요약
- github auto assign 추가

## 주요 변경사항
- .github/auto_assign.yml 파일을 추가하여 PR 생성시 assignees/reviewers를 자동으로 관리할 수 있도록 설정하였습니다.

## 리뷰시 참고사항
- skipKeywords에 wip를 추가하여 PR 제목에 wip: .....를 사용하면 reviewer가 자동으로 지정되지 않도록 설정했습니다.
- 작업중 PR을 생성하게 될 경우 사용하시면 될 것 같아요 