### PR TITLE
security filter 누락된 api path 경로 확대

### DIFF
--- a/src/main/kotlin/com/bos/backend/infrastructure/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/bos/backend/infrastructure/config/SecurityConfiguration.kt
@@ -27,7 +27,7 @@ class SecurityConfiguration(
                         "/auth/email-verification/**",
                         "/auth/password-reset",
                         "/auth/check-email",
-                        "/api/doc.html",
+                        "/api/**",
                         "/actuator/**",
                     ).permitAll()
                     .anyExchange()


### PR DESCRIPTION
## 📌 PR 요약
- security filter 누락된 api path 경로 확대

## 🔍 주요 변경사항
- 문서만 예외 추가하고, openapi.yml을 추가하지 않아 발생하는 에러 수정

## 📄 참고 문서

## ‼️ 리뷰시 참고 사항
- openapi.yml이 예외 경로에 빠져 추가합니다 😭 
