### PR TITLE
인증 토큰 갱신 API

### DIFF
--- a/src/main/kotlin/com/bos/backend/application/auth/AuthErrorCode.kt
+++ b/src/main/kotlin/com/bos/backend/application/auth/AuthErrorCode.kt
@@ -35,4 +35,16 @@ enum class AuthErrorCode(
         "유효하지 않은 토큰입니다.",
         HttpStatus.UNAUTHORIZED,
     ),
+    REFRESH_TOKEN_NOT_FOUND(
+        "리프레시 토큰을 찾을 수 없습니다.",
+        HttpStatus.BAD_REQUEST,
+    ),
+    REFRESH_TOKEN_EXPIRED(
+        "리프레시 토큰이 만료되었습니다.",
+        HttpStatus.UNAUTHORIZED,
+    ),
+    REFRESH_TOKEN_REVOKED(
+        "리프레시 토큰이 폐기되었습니다.",
+        HttpStatus.UNAUTHORIZED,
+    ),
 }

--- a/src/main/kotlin/com/bos/backend/application/service/JwtService.kt
+++ b/src/main/kotlin/com/bos/backend/application/service/JwtService.kt
@@ -9,4 +9,8 @@ interface JwtService {
     fun validateToken(token: String): Boolean
 
     fun getUserIdFromToken(token: String): Long
+
+    fun hashToken(token: String): String
+
+    fun validateTokenFormat(token: String): Boolean
 }

--- a/src/main/kotlin/com/bos/backend/domain/auth/entity/RefreshToken.kt
+++ b/src/main/kotlin/com/bos/backend/domain/auth/entity/RefreshToken.kt
@@ -1,0 +1,28 @@
+package com.bos.backend.domain.auth.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table("refresh_tokens")
+data class RefreshToken(
+    @Id
+    val id: Long? = null,
+    @Column("user_id")
+    val userId: Long,
+    @Column("token_hash")
+    val tokenHash: String,
+    @Column("expires_at")
+    val expiresAt: Instant,
+    @Column("created_at")
+    val createdAt: Instant = Instant.now(),
+    @Column("revoked_at")
+    val revokedAt: Instant? = null,
+) {
+    fun isExpired(): Boolean = Instant.now().isAfter(expiresAt)
+
+    fun isRevoked(): Boolean = revokedAt != null
+
+    fun isValid(): Boolean = !isExpired() && !isRevoked()
+}

--- a/src/main/kotlin/com/bos/backend/domain/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/bos/backend/domain/auth/repository/RefreshTokenRepository.kt
@@ -1,0 +1,18 @@
+package com.bos.backend.domain.auth.repository
+
+import com.bos.backend.domain.auth.entity.RefreshToken
+import java.time.Instant
+
+interface RefreshTokenRepository {
+    suspend fun save(refreshToken: RefreshToken): RefreshToken
+
+    suspend fun findByTokenHash(tokenHash: String): RefreshToken?
+
+    suspend fun findByUserId(userId: Long): List<RefreshToken>
+
+    suspend fun revokeByUserId(userId: Long)
+
+    suspend fun revokeByTokenHash(tokenHash: String)
+
+    suspend fun deleteExpiredTokens(now: Instant = Instant.now())
+}

--- a/src/main/kotlin/com/bos/backend/infrastructure/JwtServiceImpl.kt
+++ b/src/main/kotlin/com/bos/backend/infrastructure/JwtServiceImpl.kt
@@ -7,6 +7,7 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import java.security.MessageDigest
 import java.time.Instant
 import java.util.Date
 import javax.crypto.SecretKey
@@ -17,6 +18,10 @@ class JwtServiceImpl(
     @Value("\${application.jwt.secret}") private val secret: String,
 ) : JwtService {
     private val key: SecretKey = Keys.hmacShaKeyFor(secret.toByteArray())
+
+    companion object {
+        private const val JWT_PART_COUNT = 3
+    }
 
     override fun generateToken(
         userId: String,
@@ -37,6 +42,18 @@ class JwtServiceImpl(
     override fun validateToken(token: String): Boolean = runCatching { parseClaimFromToken(token) }.isSuccess
 
     override fun getUserIdFromToken(token: String): Long = parseClaimFromToken(token).payload.subject.toLong()
+
+    override fun hashToken(token: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(token.toByteArray())
+        return hash.joinToString("") { "%02x".format(it) }
+    }
+
+    override fun validateTokenFormat(token: String): Boolean =
+        runCatching {
+            token.split(".").size == JWT_PART_COUNT &&
+                token.matches(Regex("^[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"))
+        }.getOrDefault(false)
 
     private fun parseClaimFromToken(token: String): Jws<Claims> =
         Jwts

--- a/src/main/kotlin/com/bos/backend/infrastructure/persistence/R2dbcRefreshTokenRepository.kt
+++ b/src/main/kotlin/com/bos/backend/infrastructure/persistence/R2dbcRefreshTokenRepository.kt
@@ -1,0 +1,58 @@
+package com.bos.backend.infrastructure.persistence
+
+import com.bos.backend.domain.auth.entity.RefreshToken
+import com.bos.backend.domain.auth.repository.RefreshTokenRepository
+import org.springframework.data.r2dbc.repository.Modifying
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import java.time.Instant
+
+interface RefreshTokenCoroutineRepository : CoroutineCrudRepository<RefreshToken, Long> {
+    suspend fun findByTokenHash(tokenHash: String): RefreshToken?
+
+    suspend fun findByUserId(userId: Long): List<RefreshToken>
+
+    @Modifying
+    @Query("UPDATE refresh_tokens SET revoked_at = :revokedAt WHERE user_id = :userId AND revoked_at IS NULL")
+    suspend fun revokeByUserId(
+        userId: Long,
+        revokedAt: Instant = Instant.now(),
+    )
+
+    @Modifying
+    @Query("UPDATE refresh_tokens SET revoked_at = :revokedAt WHERE token_hash = :tokenHash AND revoked_at IS NULL")
+    suspend fun revokeByTokenHash(
+        tokenHash: String,
+        revokedAt: Instant = Instant.now(),
+    )
+
+    @Modifying
+    @Query("DELETE FROM refresh_tokens WHERE expires_at < :now OR revoked_at IS NOT NULL")
+    suspend fun deleteExpiredTokens(now: Instant): Long
+}
+
+@Repository
+class R2dbcRefreshTokenRepository(
+    private val coroutineRepository: RefreshTokenCoroutineRepository,
+) : RefreshTokenRepository {
+    override suspend fun save(refreshToken: RefreshToken): RefreshToken = coroutineRepository.save(refreshToken)
+
+    override suspend fun findByTokenHash(tokenHash: String): RefreshToken? =
+        coroutineRepository.findByTokenHash(tokenHash)
+
+    override suspend fun findByUserId(userId: Long): List<RefreshToken> = coroutineRepository.findByUserId(userId)
+
+    override suspend fun revokeByUserId(userId: Long) {
+        coroutineRepository.revokeByUserId(userId)
+    }
+
+    override suspend fun revokeByTokenHash(tokenHash: String) {
+        coroutineRepository.revokeByTokenHash(tokenHash)
+    }
+
+    // TODO: for admin
+    override suspend fun deleteExpiredTokens(now: Instant) {
+        coroutineRepository.deleteExpiredTokens(now)
+    }
+}

--- a/src/main/kotlin/com/bos/backend/presentation/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/bos/backend/presentation/auth/controller/AuthController.kt
@@ -8,6 +8,7 @@ import com.bos.backend.presentation.auth.dto.ErrorResponse
 import com.bos.backend.presentation.auth.dto.PasswordResetRequestDTO
 import com.bos.backend.presentation.auth.dto.SignInRequestDTO
 import com.bos.backend.presentation.auth.dto.SignUpRequestDTO
+import com.bos.backend.presentation.auth.dto.TokenRefreshRequestDTO
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -77,4 +78,10 @@ class AuthController(
     suspend fun withdraw(
         @AuthenticationPrincipal userId: String,
     ) = authService.deleteById(userId.toLong())
+
+    @PostMapping("/auth/token/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    suspend fun refreshToken(
+        @Valid @RequestBody request: TokenRefreshRequestDTO,
+    ): CommonSignResponseDTO = authService.refreshToken(request)
 }

--- a/src/main/kotlin/com/bos/backend/presentation/auth/dto/TokenRefreshRequestDTO.kt
+++ b/src/main/kotlin/com/bos/backend/presentation/auth/dto/TokenRefreshRequestDTO.kt
@@ -1,0 +1,8 @@
+package com.bos.backend.presentation.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class TokenRefreshRequestDTO(
+    @field:NotBlank(message = "리프레시 토큰은 필수입니다.")
+    val refreshToken: String,
+)

--- a/src/main/resources/db/migration/V2__Add_refresh_token_table.sql
+++ b/src/main/resources/db/migration/V2__Add_refresh_token_table.sql
@@ -1,0 +1,15 @@
+-- Add refresh tokens table for JWT token refresh functionality
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    token_hash VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TIMESTAMP NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_token_hash (token_hash),
+    KEY idx_user_id (user_id),
+    KEY idx_expires_at (expires_at),
+    CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/main/resources/static/api/openapi.yml
+++ b/src/main/resources/static/api/openapi.yml
@@ -266,6 +266,86 @@ paths:
             - `INVALID_TOKEN`: 유효하지 않은 토큰
         "500":
           $ref: "#/components/responses/InternalServerErrorResponseSpec"
+  /auth/token/refresh:
+    post:
+      tags:
+        - auth
+      operationId: refreshToken
+      summary: "인증 토큰 갱신"
+      description: |-
+        리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.
+
+        ## req payload
+        - 요청 바디에 리프레시 토큰을 포함해야 합니다
+
+        ## 보안 정책
+        - 리프레시 토큰 사용 시 기존 리프레시 토큰은 자동으로 폐기됩니다
+        - 새로운 액세스 토큰과 리프레시 토큰이 발급됩니다
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TokenRefreshRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/TokenRefreshResponseSpec"
+        "400":
+          description: |-
+            토큰 갱신 요청 실패
+
+            **에러 케이스:**
+            - `REFRESH_TOKEN_NOT_FOUND`: 리프레시 토큰을 찾을 수 없습니다
+            - `INVALID_TOKEN`: 유효하지 않은 토큰 형식입니다
+            - `INVALID_REQUEST`: 요청 형식이 올바르지 않습니다 (refreshToken 필드 누락)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenRefreshErrorResponse"
+              examples:
+                refresh_token_not_found:
+                  summary: 리프레시 토큰을 찾을 수 없음
+                  value:
+                    errorCode: "REFRESH_TOKEN_NOT_FOUND"
+                    message: "리프레시 토큰을 찾을 수 없습니다."
+                invalid_token:
+                  summary: 유효하지 않은 토큰 형식
+                  value:
+                    errorCode: "INVALID_TOKEN"
+                    message: "유효하지 않은 토큰입니다."
+                invalid_request:
+                  summary: 잘못된 요청 형식
+                  value:
+                    errorCode: "INVALID_REQUEST"
+                    message: "요청값이 올바르지 않습니다."
+                    errors:
+                      - field: "refreshToken"
+                        errorCode: "REQUIRED"
+                        message: "리프레시 토큰은 필수입니다."
+        "401":
+          description: |-
+            인증 실패 - 토큰이 만료되거나 폐기된 경우
+
+            **에러 케이스:**
+            - `REFRESH_TOKEN_EXPIRED`: 리프레시 토큰이 만료되었습니다
+            - `REFRESH_TOKEN_REVOKED`: 리프레시 토큰이 폐기되었습니다
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenRefreshErrorResponse"
+              examples:
+                refresh_token_expired:
+                  summary: 리프레시 토큰 만료
+                  value:
+                    errorCode: "REFRESH_TOKEN_EXPIRED"
+                    message: "리프레시 토큰이 만료되었습니다."
+                refresh_token_revoked:
+                  summary: 리프레시 토큰 폐기
+                  value:
+                    errorCode: "REFRESH_TOKEN_REVOKED"
+                    message: "리프레시 토큰이 폐기되었습니다."
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponseSpec"
   /users/me:
     get:
       tags:
@@ -1071,6 +1151,53 @@ components:
           format: int64
           description: 읽지 않은 알림 수
           example: 5
+    TokenRefreshRequest:
+      type: object
+      required:
+        - refreshToken
+      properties:
+        refreshToken:
+          type: string
+          description: 리프레시 토큰
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    TokenRefreshErrorResponse:
+      type: object
+      required:
+        - errorCode
+        - message
+      properties:
+        errorCode:
+          type: string
+          description: 에러 코드
+          enum:
+            - REFRESH_TOKEN_NOT_FOUND
+            - REFRESH_TOKEN_EXPIRED
+            - REFRESH_TOKEN_REVOKED
+            - INVALID_TOKEN
+            - INVALID_REQUEST
+          example: "REFRESH_TOKEN_EXPIRED"
+        message:
+          type: string
+          description: 에러 메시지
+          example: "리프레시 토큰이 만료되었습니다."
+        errors:
+          type: array
+          description: 필드별 검증 오류 (INVALID_REQUEST 시에만 포함)
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+                description: 오류가 발생한 필드명
+                example: "refreshToken"
+              errorCode:
+                type: string
+                description: 필드별 에러 코드
+                example: "REQUIRED"
+              message:
+                type: string
+                description: 필드별 에러 메시지
+                example: "리프레시 토큰은 필수입니다."
 
   requestBodies:
     SignUpRequestSpec:
@@ -1140,3 +1267,13 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/UserProfileResponse"
+    TokenRefreshResponseSpec:
+      description: |-
+        토큰 갱신 성공
+
+        새로운 액세스 토큰과 리프레시 토큰이 발급됩니다.
+        기존 리프레시 토큰은 자동으로 폐기됩니다.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CommonSignResponseBody"

--- a/src/test/kotlin/com/bos/backend/application/auth/AuthServiceRefreshTokenTest.kt
+++ b/src/test/kotlin/com/bos/backend/application/auth/AuthServiceRefreshTokenTest.kt
@@ -1,0 +1,146 @@
+package com.bos.backend.application.auth
+
+import com.bos.backend.application.CustomException
+import com.bos.backend.application.service.JwtService
+import com.bos.backend.domain.auth.entity.RefreshToken
+import com.bos.backend.domain.auth.repository.RefreshTokenRepository
+import com.bos.backend.presentation.auth.dto.TokenRefreshRequestDTO
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.time.Instant
+
+class AuthServiceRefreshTokenTest : StringSpec({
+    val jwtService = mockk<JwtService>()
+    val refreshTokenRepository = mockk<RefreshTokenRepository>()
+    val accessTokenExpiration = 3600L
+    val refreshTokenExpiration = 2592000L // 30일
+
+    val sut =
+        AuthService(
+            authStrategyResolver = mockk(),
+            jwtService = jwtService,
+            userAuthRepository = mockk(),
+            userTermsAgreementRepository = mockk(),
+            userRepository = mockk(),
+            emailVerificationService = mockk(),
+            refreshTokenRepository = refreshTokenRepository,
+            accessTokenExpiration = accessTokenExpiration,
+            refreshTokenExpiration = refreshTokenExpiration,
+        )
+
+    "refreshToken은 유효한 토큰으로 새로운 토큰을 발급한다" {
+        val userId = 1L
+        val refreshTokenValue = "valid.refresh.token"
+        val tokenHash = "hashedRefreshToken"
+        val newAccessToken = "new.access.token"
+        val newRefreshToken = "new.refresh.token"
+
+        val storedRefreshToken =
+            RefreshToken(
+                id = 1L,
+                userId = userId,
+                tokenHash = tokenHash,
+                expiresAt = Instant.now().plusSeconds(refreshTokenExpiration),
+            )
+
+        coEvery { jwtService.validateTokenFormat(refreshTokenValue) } returns true
+        coEvery { jwtService.hashToken(refreshTokenValue) } returns tokenHash
+        coEvery { refreshTokenRepository.findByTokenHash(tokenHash) } returns storedRefreshToken
+        coEvery { refreshTokenRepository.revokeByTokenHash(tokenHash) } returns Unit
+        coEvery { jwtService.generateToken(userId.toString(), accessTokenExpiration) } returns newAccessToken
+        coEvery { jwtService.generateToken(userId.toString(), refreshTokenExpiration) } returns newRefreshToken
+        coEvery { jwtService.hashToken(newRefreshToken) } returns "newTokenHash"
+        coEvery { refreshTokenRepository.save(any()) } returns mockk()
+
+        val request = TokenRefreshRequestDTO(refreshTokenValue)
+        val result = sut.refreshToken(request)
+
+        result.accessToken shouldBe newAccessToken
+        result.refreshToken shouldBe newRefreshToken
+
+        coVerify { refreshTokenRepository.revokeByTokenHash(tokenHash) }
+        coVerify { refreshTokenRepository.save(any()) }
+    }
+
+    "refreshToken은 유효하지 않은 refresh token 형식에 대해 예외를 발생시킨다" {
+        val refreshTokenValue = "invalid.refresh.token"
+
+        coEvery { jwtService.validateTokenFormat(refreshTokenValue) } returns false
+
+        val request = TokenRefreshRequestDTO(refreshTokenValue)
+
+        shouldThrow<CustomException> {
+            sut.refreshToken(request)
+        }.errorCode shouldBe AuthErrorCode.INVALID_TOKEN.toString()
+    }
+
+    "refreshToken은 존재하지 않는 refresh token에 대해 예외를 발생시킨다" {
+        val refreshTokenValue = "nonexistent.refresh.token"
+        val tokenHash = "nonexistentHash"
+
+        coEvery { jwtService.validateTokenFormat(refreshTokenValue) } returns true
+        coEvery { jwtService.hashToken(refreshTokenValue) } returns tokenHash
+        coEvery { refreshTokenRepository.findByTokenHash(tokenHash) } returns null
+
+        val request = TokenRefreshRequestDTO(refreshTokenValue)
+
+        shouldThrow<CustomException> {
+            sut.refreshToken(request)
+        }.errorCode shouldBe AuthErrorCode.REFRESH_TOKEN_NOT_FOUND.toString()
+    }
+
+    "refreshToken은 만료된 refresh token에 대해 예외를 발생시킨다" {
+        val userId = 1L
+        val refreshTokenValue = "expired.refresh.token"
+        val tokenHash = "expiredTokenHash"
+
+        // 1시간 전 만료
+        val expiredRefreshToken =
+            RefreshToken(
+                id = 1L,
+                userId = userId,
+                tokenHash = tokenHash,
+                expiresAt = Instant.now().minusSeconds(3600),
+            )
+
+        coEvery { jwtService.validateTokenFormat(refreshTokenValue) } returns true
+        coEvery { jwtService.hashToken(refreshTokenValue) } returns tokenHash
+        coEvery { refreshTokenRepository.findByTokenHash(tokenHash) } returns expiredRefreshToken
+
+        val request = TokenRefreshRequestDTO(refreshTokenValue)
+
+        shouldThrow<CustomException> {
+            sut.refreshToken(request)
+        }.errorCode shouldBe AuthErrorCode.REFRESH_TOKEN_EXPIRED.toString()
+    }
+
+    "refreshToken은 폐기된 refresh token에 대해 예외를 발생시킨다" {
+        val userId = 1L
+        val refreshTokenValue = "revoked.refresh.token"
+        val tokenHash = "revokedTokenHash"
+
+        // 1시간 전 폐기
+        val revokedRefreshToken =
+            RefreshToken(
+                id = 1L,
+                userId = userId,
+                tokenHash = tokenHash,
+                expiresAt = Instant.now().plusSeconds(refreshTokenExpiration),
+                revokedAt = Instant.now().minusSeconds(3600),
+            )
+
+        coEvery { jwtService.validateTokenFormat(refreshTokenValue) } returns true
+        coEvery { jwtService.hashToken(refreshTokenValue) } returns tokenHash
+        coEvery { refreshTokenRepository.findByTokenHash(tokenHash) } returns revokedRefreshToken
+
+        val request = TokenRefreshRequestDTO(refreshTokenValue)
+
+        shouldThrow<CustomException> {
+            sut.refreshToken(request)
+        }.errorCode shouldBe AuthErrorCode.REFRESH_TOKEN_REVOKED.toString()
+    }
+})

--- a/src/test/kotlin/com/bos/backend/infrastructure/JwtServiceImplTest.kt
+++ b/src/test/kotlin/com/bos/backend/infrastructure/JwtServiceImplTest.kt
@@ -36,4 +36,44 @@ class JwtServiceImplTest :
 
             sut.getUserIdFromToken(token) shouldBe 12345L
         }
+
+        "hashToken은 동일한 토큰에 대해 동일한 해시를 반환한다" {
+            val token = sut.generateToken("12345", 3600L)
+
+            val hash1 = sut.hashToken(token)
+            val hash2 = sut.hashToken(token)
+
+            hash1 shouldBe hash2
+        }
+
+        "hashToken은 다른 토큰에 대해 다른 해시를 반환한다" {
+            val token1 = sut.generateToken("12345", 3600L)
+            val token2 = sut.generateToken("67890", 3600L)
+
+            val hash1 = sut.hashToken(token1)
+            val hash2 = sut.hashToken(token2)
+
+            hash1 shouldNotBe hash2
+        }
+
+        "validateTokenFormat은 올바른 JWT 형식에 대해 true를 반환한다" {
+            val validToken = sut.generateToken("12345", 3600L)
+
+            sut.validateTokenFormat(validToken) shouldBe true
+        }
+
+        "validateTokenFormat은 잘못된 형식의 토큰에 대해 false를 반환한다" {
+            val invalidTokens =
+                listOf(
+                    "invalid",
+                    "invalid.token",
+                    "invalid..token",
+                    "",
+                    "a.b.c.d",
+                )
+
+            invalidTokens.forEach { invalidToken ->
+                sut.validateTokenFormat(invalidToken) shouldBe false
+            }
+        }
     })


### PR DESCRIPTION
## 📌 PR 요약
- 인증 토큰 갱신 API 추가

## 🔍 주요 변경사항
- refresh_tokens 엔티티 추가
- 인증 토큰 갱신 API 추가

## 📄 참고 문서
- [이전 노션 태스크](https://www.notion.so/shinhyojeong/API-22fcb39f28c28005b98bf2df668161ce?source=copy_link)
- [지라 티켓](https://buildingownersoon.atlassian.net/browse/SCRUM-51)

## ‼️ 리뷰시 참고 사항
- accessToken을 입력받을 필요는 없을것 같아 refreshToken만 입력하도록 변경했습니다
- flyway가 적용된 이후에 반영되어야 하는 pr입니다.
