### PR TITLE
납부일 월말 일자 조정

### DIFF
--- a/src/main/kotlin/com/bos/backend/application/transaction/TransactionService.kt
+++ b/src/main/kotlin/com/bos/backend/application/transaction/TransactionService.kt
@@ -140,7 +140,7 @@ class TransactionService(
         val monthsList = mutableListOf<LocalDate>()
         while (currentDate.isBefore(targetDate) || currentDate.isEqual(targetDate)) {
             monthsList.add(currentDate)
-            currentDate = currentDate.plusMonths(1)
+            currentDate = calculateNextPaymentDate(currentDate, paymentDay)
         }
 
         if (monthsList.isNotEmpty()) {
@@ -192,7 +192,7 @@ class TransactionService(
             )
 
             remainingAmount -= paymentAmount
-            currentDate = currentDate.plusMonths(1)
+            currentDate = calculateNextPaymentDate(currentDate, paymentDay)
         }
 
         return schedules
@@ -201,12 +201,20 @@ class TransactionService(
     private fun calculateNextPaymentDate(
         baseDate: LocalDate,
         paymentDay: Int,
-    ): LocalDate =
-        if (baseDate.dayOfMonth > paymentDay) {
-            baseDate.plusMonths(1).withDayOfMonth(paymentDay)
-        } else {
-            baseDate.withDayOfMonth(paymentDay)
-        }
+    ): LocalDate {
+        val targetMonth =
+            if (baseDate.dayOfMonth > paymentDay) {
+                baseDate.plusMonths(1)
+            } else {
+                baseDate
+            }
+
+        val lastDayOfMonth = targetMonth.lengthOfMonth()
+
+        val adjustedPaymentDay = if (paymentDay > lastDayOfMonth) lastDayOfMonth else paymentDay
+
+        return targetMonth.withDayOfMonth(adjustedPaymentDay)
+    }
 
     private fun toTransactionResponseDTO(transaction: Transaction): TransactionResponseDTO =
         TransactionResponseDTO(

--- a/src/main/kotlin/com/bos/backend/presentation/transaction/dto/CreateTransactionRequestDTO.kt
+++ b/src/main/kotlin/com/bos/backend/presentation/transaction/dto/CreateTransactionRequestDTO.kt
@@ -5,9 +5,12 @@ import com.bos.backend.domain.transaction.enum.RepaymentType
 import com.bos.backend.domain.transaction.enum.TransactionType
 import com.bos.backend.domain.user.entity.Character
 import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.PositiveOrZero
+import jakarta.validation.constraints.Size
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -15,6 +18,7 @@ data class CreateTransactionRequestDTO(
     @field:NotNull(message = "거래 유형은 필수입니다")
     val transactionType: TransactionType,
     @field:NotBlank(message = "상대방 이름은 필수입니다")
+    @field:Size(max = 12, message = "상대방 이름은 12자 이내여야 합니다")
     val counterpartName: String,
     @field:NotNull(message = "상대방 캐릭터는 필수입니다")
     val counterpartCharacter: Character,
@@ -24,16 +28,19 @@ data class CreateTransactionRequestDTO(
     @field:NotNull(message = "거래일은 필수입니다")
     val transactionDate: LocalDate,
     @field:NotNull(message = "전체 금액은 필수입니다")
-    @field:DecimalMin(value = "0.01", message = "전체 금액은 0보다 커야 합니다")
+    @field:DecimalMin(value = "10000", message = "전체 금액은 10000원 이상이어야 합니다")
     val totalAmount: BigDecimal,
-    @field:PositiveOrZero(message = "완료된 금액은 0 이상이어야 합니다")
+    @field:DecimalMin(value = "10000", message = "완료된 금액은 10000원 이상이어야 합니다")
     val completedAmount: BigDecimal?,
+    @field:Size(max = 50, message = "메모는 50자 이내여야 합니다")
     val memo: String?,
     @field:NotNull(message = "상환 유형은 필수입니다")
     val repaymentType: RepaymentType,
     val targetDate: LocalDate?,
     @field:PositiveOrZero(message = "월 납부 금액은 0 이상이어야 합니다")
     val monthlyAmount: BigDecimal?,
+    @field:Min(value = 1, message = "매달 납부일은 1 이상이어야 합니다")
+    @field:Max(value = 31, message = "매달 납부일은 31 이하여야 합니다")
     val paymentDay: Int?,
     val hasTargetDate: Boolean?,
 )

--- a/src/main/kotlin/com/bos/backend/presentation/transaction/dto/UpdateTransactionRequestDTO.kt
+++ b/src/main/kotlin/com/bos/backend/presentation/transaction/dto/UpdateTransactionRequestDTO.kt
@@ -4,14 +4,17 @@ import com.bos.backend.domain.transaction.enum.RelationshipType
 import com.bos.backend.domain.user.entity.Character
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 
 data class UpdateTransactionRequestDTO(
     @field:NotBlank(message = "상대방 이름은 필수입니다")
+    @field:Size(max = 12, message = "상대방 이름은 12자 이내여야 합니다")
     val counterpartName: String,
     @field:NotNull(message = "상대방 캐릭터는 필수입니다")
     val counterpartCharacter: Character,
     @field:NotNull(message = "관계는 필수입니다")
     val relationship: RelationshipType,
     val customRelationship: String?,
+    @field:Size(max = 50, message = "메모는 50자 이내여야 합니다")
     val memo: String?,
 )


### PR DESCRIPTION
## 📌 PR 요약
- 어떤 작업을 했는지 간단히 설명해주세요.
- 29~31 입력 시, 해당 일자를 보유하고 있지 않은 달에는 자동 월말 조정된다는 안내 제공

## 🔍 주요 변경사항
- 주요 로직/파일/구조 변경 내용을 설명해주세요.
- 필드 validation 추가
- 월말 입력시 해당일자를 보유하고 있지 않을 경우 자동 조정

## 📄 참고 문서
- 작업 관련하여 참고할 문서가 있다면 첨부해주세요.
- [문서](링크)

## ‼️ 리뷰시 참고 사항
- 리뷰시 유의 해야할 사항, 체크 해야할게 있다면 함께 적어주세요.
